### PR TITLE
Handle MissingResourceException

### DIFF
--- a/src/IntlExtension.php
+++ b/src/IntlExtension.php
@@ -13,6 +13,7 @@ namespace Twig\Extra\Intl;
 
 use Symfony\Component\Intl\Countries;
 use Symfony\Component\Intl\Currencies;
+use Symfony\Component\Intl\Exception\MissingResourceException;
 use Symfony\Component\Intl\Languages;
 use Symfony\Component\Intl\Locales;
 use Symfony\Component\Intl\Timezones;
@@ -171,7 +172,11 @@ final class IntlExtension extends AbstractExtension
 
     public function getLanguageName(string $language, string $locale = null): string
     {
-        return Languages::getName($language, $locale);
+        try {
+            return Languages::getName($language, $locale);
+        } catch (MissingResourceException $exception) {
+            return $language;
+        }
     }
 
     public function getLocaleName(string $data, string $locale = null): string

--- a/tests/Fixtures/language_name.test
+++ b/tests/Fixtures/language_name.test
@@ -6,6 +6,7 @@
 {{ 'de'|language_name('fr') }}
 {{ 'fr'|language_name('fr_FR') }}
 {{ 'fr_CA'|language_name('fr_FR') }}
+{{ 'UNKNOWN'|language_name() }}
 --DATA--
 return [];
 --EXPECT--
@@ -14,3 +15,4 @@ French
 allemand
 français
 français canadien
+UNKNOWN


### PR DESCRIPTION
When you want to get the language name of a language you can type:
```twig
{{ inputLanguage | language_name }}
```

But if `inputLanguage` is not a valid language, a `MissingResourceException` is thrown, blowing up the whole page.

Since in Twig, there is no way to catch this exception, it becomes extremely hard to work with these helpers if you have no control over the input. There is also no way to first check if the language exists before invoking the filter.

The same applies to all the other `Intl::` calls that happen. They can all throw the same exception. I didn't change that yet, because I first want to know your opinion about this. If you agree, that it should fallback to the input, then I will change the rest too.
