### PR TITLE
add ext-intl in require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
+        "ext-intl": "*",
         "twig/twig": "^2.4|^3.0",
         "symfony/intl": "^4.3|^5.0"
     },


### PR DESCRIPTION
This is a necessary dependency.

Otherwise, when upgrading symfony 5.0.* to 5.2.

The inability to run composer require twig/intl-extra.

P.s. Excuse my English, I'm learning Japanese.