### PR TITLE
Add the new PHP 8.0 IntlDateFormatter::RELATIVE_* constants for date formatting

### DIFF
--- a/IntlExtension.php
+++ b/IntlExtension.php
@@ -31,6 +31,17 @@ final class IntlExtension extends AbstractExtension
         'medium' => \IntlDateFormatter::MEDIUM,
         'long' => \IntlDateFormatter::LONG,
         'full' => \IntlDateFormatter::FULL,
+        'relative_short' => \IntlDateFormatter::RELATIVE_SHORT,
+        'relative_medium' => \IntlDateFormatter::RELATIVE_MEDIUM,
+        'relative_long' => \IntlDateFormatter::RELATIVE_LONG,
+        'relative_full' => \IntlDateFormatter::RELATIVE_FULL,
+    ];
+    private const TIME_FORMATS = [
+        'none' => \IntlDateFormatter::NONE,
+        'short' => \IntlDateFormatter::SHORT,
+        'medium' => \IntlDateFormatter::MEDIUM,
+        'long' => \IntlDateFormatter::LONG,
+        'full' => \IntlDateFormatter::FULL,
     ];
     private const NUMBER_TYPES = [
         'default' => \NumberFormatter::TYPE_DEFAULT,
@@ -313,8 +324,8 @@ final class IntlExtension extends AbstractExtension
             throw new RuntimeError(sprintf('The date format "%s" does not exist, known formats are: "%s".', $dateFormat, implode('", "', array_keys(self::DATE_FORMATS))));
         }
 
-        if (null !== $timeFormat && !isset(self::DATE_FORMATS[$timeFormat])) {
-            throw new RuntimeError(sprintf('The time format "%s" does not exist, known formats are: "%s".', $timeFormat, implode('", "', array_keys(self::DATE_FORMATS))));
+        if (null !== $timeFormat && !isset(self::TIME_FORMATS[$timeFormat])) {
+            throw new RuntimeError(sprintf('The time format "%s" does not exist, known formats are: "%s".', $timeFormat, implode('", "', array_keys(self::TIME_FORMATS))));
         }
 
         if (null === $locale) {
@@ -324,7 +335,7 @@ final class IntlExtension extends AbstractExtension
         $calendar = 'gregorian' === $calendar ? \IntlDateFormatter::GREGORIAN : \IntlDateFormatter::TRADITIONAL;
 
         $dateFormatValue = self::DATE_FORMATS[$dateFormat] ?? null;
-        $timeFormatValue = self::DATE_FORMATS[$timeFormat] ?? null;
+        $timeFormatValue = self::TIME_FORMATS[$timeFormat] ?? null;
 
         if ($this->dateFormatterPrototype) {
             $dateFormatValue = $dateFormatValue ?: $this->dateFormatterPrototype->getDateType();

--- a/Tests/Fixtures/format_date.test
+++ b/Tests/Fixtures/format_date.test
@@ -6,6 +6,8 @@
 {{ '2019-08-07 23:39:12'|format_datetime('none', 'short', locale='fr') }}
 {{ '2019-08-07 23:39:12'|format_datetime('short', 'none', locale='fr') }}
 {{ '2019-08-07 23:39:12'|format_datetime('full', 'full', locale='fr') }}
+{{ '2019-08-07 23:39:12'|format_datetime('relative_short', 'none', locale='fr') }}
+{{ '2019-08-07 23:39:12'|format_datetime('relative_full', 'full', locale='fr') }}
 {{ '2019-08-07 23:39:12'|format_datetime(pattern="hh 'oclock' a, zzzz") }}
 
 {{ '2019-08-07 23:39:12'|format_date }}
@@ -17,6 +19,8 @@ return [];
 Aug 7, 2019, 11:39:12 PM
 7 août 2019 à 23:39:12
 23:39
+07/08/2019
+mercredi 7 août 2019 à 23:39:12 Temps universel coordonné
 07/08/2019
 mercredi 7 août 2019 à 23:39:12 Temps universel coordonné
 11 oclock PM, Coordinated Universal Time


### PR DESCRIPTION
Since PHP 8.0, IntlDateFormatter get new constants to format relative dates. This PR add those constants.