### PR TITLE
`format_datetime` ignores date/time format with `IntlDateFormatter` prototype

### DIFF
--- a/IntlExtension.php
+++ b/IntlExtension.php
@@ -331,7 +331,13 @@ final class IntlExtension extends AbstractExtension
             $timeFormatValue = $timeFormatValue ?: $this->dateFormatterPrototype->getTimeType();
             $timezone = $timezone ?: $this->dateFormatterPrototype->getTimeType();
             $calendar = $calendar ?: $this->dateFormatterPrototype->getCalendar();
-            $pattern = $pattern ?: $this->dateFormatterPrototype->getPattern();
+            if ('' === $pattern) {
+                if (!$dateFormat && !$timeFormat) {    // no explicit values for either format given
+                    $pattern = $this->dateFormatterPrototype->getPattern();
+                } else {
+                    $pattern = null;
+                }
+            }
         }
 
         $hash = $locale.'|'.$dateFormatValue.'|'.$timeFormatValue.'|'.$timezone->getName().'|'.$calendar.'|'.$pattern;


### PR DESCRIPTION
I originally described this issue in https://github.com/twigphp/Twig/issues/3568#issuecomment-931382860 but have created this PR to keep the discussion focussed.