### PR TITLE
remove number type `currency` as `NumberFormatter::TYPE_CURRENCY` is deprecated in PHP 8.3

### DIFF
--- a/IntlExtension.php
+++ b/IntlExtension.php
@@ -37,7 +37,6 @@ final class IntlExtension extends AbstractExtension
         'int32' => \NumberFormatter::TYPE_INT32,
         'int64' => \NumberFormatter::TYPE_INT64,
         'double' => \NumberFormatter::TYPE_DOUBLE,
-        'currency' => \NumberFormatter::TYPE_CURRENCY,
     ];
     private const NUMBER_STYLES = [
         'decimal' => \NumberFormatter::DECIMAL,


### PR DESCRIPTION
Testing showed no side-effects.