### PR TITLE
Fix exception when timezone is false

### DIFF
--- a/IntlExtension.php
+++ b/IntlExtension.php
@@ -372,7 +372,7 @@ final class IntlExtension extends AbstractExtension
         $date = CoreExtension::dateConverter($env, $date, $timezone);
 
         $formatterTimezone = $timezone;
-        if (null === $formatterTimezone) {
+        if (null === $formatterTimezone || false === $formatterTimezone) {
             $formatterTimezone = $date->getTimezone();
         } elseif (\is_string($formatterTimezone)) {
             $formatterTimezone = new \DateTimeZone($timezone);


### PR DESCRIPTION
When passing `false` in the timezone param, twig returns an exception:

> An exception has been thrown during the rendering of a template ("Twig\Extra\Intl\IntlExtension::createDateFormatter(): Argument 5 ($timezone) must be of type ?DateTimeZone, bool given

Passing `false` is supported and allows to skip the timezone conversion.