### PR TITLE
Require correct twig core version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "twig/twig": "^3.0",
+        "twig/twig": "^3.9",
         "symfony/intl": "^5.4|^6.4|^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
This changes the composer version constraint on the core twig library, to require atleast version `3.9.0`. This is necessary since `twig/intl-extra` now depends on `CoreExtension::dateConverter()` which was only introduced with the release of version 3.9 (see: https://github.com/twigphp/Twig/commit/54d34b969b256ecd1c7aa3416205206d87686ef7).