### PR TITLE
Add support for ALPHA-3 country_name

### DIFF
--- a/IntlExtension.php
+++ b/IntlExtension.php
@@ -198,6 +198,9 @@ final class IntlExtension extends AbstractExtension
         }
 
         try {
+            if (mb_strlen($country) == 3) {
+                return Countries::getAlpha3Name($country);
+            }
             return Countries::getName($country, $locale);
         } catch (MissingResourceException $exception) {
             return $country;


### PR DESCRIPTION
Extend method getCountryName() to support ISO-3166 ALPHA-3 country codes in addition to the ALPHA-2 country codes.